### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ The quickest way to get started will be to fork the [Kickflip iOS SDK example](h
 }
 ```
 
-## Cocoapods Setup
+## CocoaPods Setup
 
-You'll need to install [Cocoapods](http://cocoapods.org) first.
+You'll need to install [CocoaPods](http://cocoapods.org) first.
     
 Add the following line to your `Podfile`:
 
     pod 'Kickflip'
 
-Then run Cocoapods to install all of the dependencies:
+Then run CocoaPods to install all of the dependencies:
 
     $ pod install
 
-As with all projects that depend on Cocoapods, make sure to open the new `.xcworkspace` file, not your `.xcodeproj` file.
+As with all projects that depend on CocoaPods, make sure to open the new `.xcworkspace` file, not your `.xcodeproj` file.
     
 ## Documentation
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
